### PR TITLE
fix post-rotation compression and removal AND rollback Maxbytes restriction

### DIFF
--- a/testing_test.go
+++ b/testing_test.go
@@ -71,7 +71,6 @@ func isNilUp(obtained interface{}, t testing.TB, caller int) {
 }
 
 // notNil reports a failure if the given value is nil.
-// nolint: deadcode
 func notNil(obtained interface{}, t testing.TB) {
 	notNilUp(obtained, t, 1)
 }


### PR DESCRIPTION
This PR is covering:

1. rollback  https://github.com/fahedouch/go-logrotate/pull/10 ( keep upgrade to go1.19)
2. drop go-routines for `post-rotation compression and removal` of stale log files (concurrency safe write) (see https://github.com/fahedouch/go-logrotate/blob/main/logrotate.go#L130-L131) . Why ? ( see https://github.com/containerd/nerdctl/issues/1222 and https://github.com/containerd/nerdctl/issues/1580)
3. fix Comments