### PR TITLE
remove max file size check in openExistingOrNew

### DIFF
--- a/logrotate.go
+++ b/logrotate.go
@@ -136,7 +136,7 @@ func (l *Logger) Write(p []byte) (n int, err error) {
 	}
 
 	if l.file == nil {
-		if err = l.openExistingOrNew(len(p)); err != nil {
+		if err = l.openExistingOrNew(); err != nil {
 			return 0, err
 		}
 	}
@@ -272,7 +272,7 @@ func (l *Logger) backupName(name, nameTimeFormat string, local bool) (string, er
 // openExistingOrNew opens the logfile if it exists and if the current write
 // would not put it over MaxBytes.  If there is no such file or the write would
 // put it over the MaxBytes, a new file is created.
-func (l *Logger) openExistingOrNew(writeLen int) error {
+func (l *Logger) openExistingOrNew() error {
 	l.millRun()
 
 	filename := l.filename()
@@ -282,10 +282,6 @@ func (l *Logger) openExistingOrNew(writeLen int) error {
 	}
 	if err != nil {
 		return fmt.Errorf("error getting log file info: %s", err)
-	}
-
-	if info.Size()+int64(writeLen) >= l.max(int64(writeLen)) {
-		return l.rotate()
 	}
 
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0644)

--- a/logrotate.go
+++ b/logrotate.go
@@ -269,9 +269,8 @@ func (l *Logger) backupName(name, nameTimeFormat string, local bool) (string, er
 	return filepath.Join(dir, filename), nil
 }
 
-// openExistingOrNew opens the logfile if it exists and if the current write
-// would not put it over MaxBytes.  If there is no such file or the write would
-// put it over the MaxBytes, a new file is created.
+// openExistingOrNew opens the logfile if it exists.
+// If there is no such file a new file is created.
 func (l *Logger) openExistingOrNew() error {
 	l.millRun()
 


### PR DESCRIPTION
The current implementation of logrotate.openExistingOrNew has multiple checks to verify if there is an memory overflow on the existing log file and rotates it if true. 

[This code in particular](https://github.com/fahedouch/go-logrotate/blob/6a8beddaea39b2b9c77109d7fa2fe92053c063e5/logrotate.go#L287) checks the current log file size when logger.size is not yet set. (which defaults l.size to 0) 
The [max](https://github.com/fahedouch/go-logrotate/blob/6a8beddaea39b2b9c77109d7fa2fe92053c063e5/logrotate.go#L493) function always returns a number less than `filesize + writeLen` resulting in the rotate function being called. This behavior is seen when [maxBytes is set to -1](https://github.com/fahedouch/go-logrotate/blob/6a8beddaea39b2b9c77109d7fa2fe92053c063e5/logrotate.go#L495). 

This results in nerdctl container logs failing to persist in the same log file as each new write rotates the logs and overwrites the older log file. 
[nerdctl issue](https://github.com/containerd/nerdctl/issues/3661)